### PR TITLE
Fix Layer Filtering for duplicates in updateLayerList()

### DIFF
--- a/mapvote.js
+++ b/mapvote.js
@@ -876,7 +876,7 @@ export default class MapVote extends DiscordBasePlugin {
         );
 
         for (const layer of response.data.Maps) {
-            if (!Layers.layers.find((e) => e.layerid == layer.layerid)) Layers.layers.push(new Layer(layer));
+            if (!Layers.layers.find((e) => e.layerid == layer.rawName)) Layers.layers.push(new Layer(layer));
         }
 
         this.verbose(1, 'Layer list updated');


### PR DESCRIPTION
The raw JSON from the request doesn't use .layerid, instead it uses rawName as per the Layer.js file.

https://github.com/Team-Silver-Sphere/SquadJS/blob/cf882aa3d2e490945e89a91dec524e0aa02ac5cb/squad-server/layers/layer.js#L5

This is the cause of the bug reported in Squad RCON discord via RPP GHOTI, where the layers array had duplicate entries.