### PR TITLE
Include includeMainAssetsInBroadcast option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -183,6 +183,13 @@ Enables the broadcast at the end of the voting.
 ```json
 true
 ```
+#### includeMainAssetsInBroadcast
+###### Description
+Shows/Hides Helis and Tanks in the broadcast if they are included in the voting layer.
+###### Default
+```json
+true
+```
 #### allowedSameMapEntries
 ###### Description
 Allowed max NUMBER of times a map could appear in the vote list.
@@ -265,6 +272,7 @@ Array of timeframes that allows to override options based on local time. See exa
     "voteBroadcastMessage": "✯ MAPVOTE ✯\nVote for the next map by writing in chat the corresponding number!",
     "voteWinnerBroadcastMessage": "✯ MAPVOTE ✯\nThe winning layer is\n\n",
     "showWinnerBroadcastMessage": true,
+    "includeMainAssetsInBroadcast" true,
     "allowedSameMapEntries": 1,
     "logToDiscord": true,
     "channelID": "112233445566778899",


### PR DESCRIPTION
Include includeMainAssetsInBroadcast option from [5b17f09](https://github.com/fantinodavide/squad-js-map-vote/commit/5b17f0961a25d6c4fca2a6011cb3d976dbd74cf9) to the README.MD file 