### PR TITLE
Added missing colon in includeMainAssetsInBroadcast option.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -281,7 +281,7 @@ Can be used to prevent situation when insignificant number of players decide wha
     "voteBroadcastMessage": "✯ MAPVOTE ✯\nVote for the next map by writing in chat the corresponding number!",
     "voteWinnerBroadcastMessage": "✯ MAPVOTE ✯\nThe winning layer is\n\n",
     "showWinnerBroadcastMessage": true,
-    "includeMainAssetsInBroadcast" true,
+    "includeMainAssetsInBroadcast": true,
     "allowedSameMapEntries": 1,
     "logToDiscord": true,
     "channelID": "112233445566778899",


### PR DESCRIPTION
Missing colon of the **includeMainAssetsInBroadcast** option. is causing a crash due to an invalid JSON format.